### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  phpunit:
+    name: Tests (PHPUnit) L${{ matrix.laravel }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        laravel: [6, 8, 9]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+
+      - name: Install dependencies
+        run: composer require "laravel/framework:^${{matrix.laravel}}.0"
+      - name: Run tests
+        run: vendor/bin/phpunit
+
+  php-cs-fixer:
+    name: Code style (php-cs-fixer)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install php-cs-fixer
+        run: composer global require friendsofphp/php-cs-fixer
+      - name: Run php-cs-fixer
+        run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
+      - name: Commit changes from php-cs-fixer
+        uses: EndBug/add-and-commit@v5
+        with:
+          author_name: Samuel Štancl
+          author_email: samuel.stancl@gmail.com
+          message: Fix code style (php-cs-fixer)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        laravel: [6, 8, 9]
+        laravel: [8, 9]
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 composer.lock
+.phpunit.result.cache
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,141 @@
+<?php
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$rules = [
+    'array_syntax' => ['syntax' => 'short'],
+    'binary_operator_spaces' => [
+        'default' => 'single_space',
+        'operators' => [
+            '=>' => null,
+            '|' => 'no_space',
+        ],
+    ],
+    'blank_line_after_namespace' => true,
+    'blank_line_after_opening_tag' => true,
+    'no_superfluous_phpdoc_tags' => true,
+    'blank_line_before_statement' => [
+        'statements' => ['return'],
+    ],
+    'braces' => true,
+    'cast_spaces' => true,
+    'class_definition' => true,
+    'concat_space' => [
+        'spacing' => 'one',
+    ],
+    'declare_equal_normalize' => true,
+    'elseif' => true,
+    'encoding' => true,
+    'full_opening_tag' => true,
+    'declare_strict_types' => true,
+    'fully_qualified_strict_types' => true, // added by Shift
+    'function_declaration' => true,
+    'function_typehint_space' => true,
+    'heredoc_to_nowdoc' => true,
+    'include' => true,
+    'increment_style' => ['style' => 'post'],
+    'indentation_type' => true,
+    'linebreak_after_opening_tag' => true,
+    'line_ending' => true,
+    'lowercase_cast' => true,
+    'constant_case' => true,
+    'lowercase_keywords' => true,
+    'lowercase_static_reference' => true, // added from Symfony
+    'magic_method_casing' => true, // added from Symfony
+    'magic_constant_casing' => true,
+    'method_argument_space' => true,
+    'native_function_casing' => true,
+    'no_alias_functions' => true,
+    'no_extra_blank_lines' => [
+        'tokens' => [
+            'extra',
+            'throw',
+            'use',
+            'use_trait',
+        ],
+    ],
+    'no_blank_lines_after_class_opening' => true,
+    'no_blank_lines_after_phpdoc' => true,
+    'no_closing_tag' => true,
+    'no_empty_phpdoc' => true,
+    'no_empty_statement' => true,
+    'no_leading_import_slash' => true,
+    'no_leading_namespace_whitespace' => true,
+    'no_mixed_echo_print' => [
+        'use' => 'echo',
+    ],
+    'no_multiline_whitespace_around_double_arrow' => true,
+    'multiline_whitespace_before_semicolons' => [
+        'strategy' => 'no_multi_line',
+    ],
+    'no_short_bool_cast' => true,
+    'no_singleline_whitespace_before_semicolons' => true,
+    'no_spaces_after_function_name' => true,
+    'no_spaces_around_offset' => true,
+    'no_spaces_inside_parenthesis' => true,
+    'no_trailing_comma_in_list_call' => true,
+    'no_trailing_comma_in_singleline_array' => true,
+    'no_trailing_whitespace' => true,
+    'no_trailing_whitespace_in_comment' => true,
+    'no_unneeded_control_parentheses' => true,
+    'no_unreachable_default_argument_value' => true,
+    'no_useless_return' => true,
+    'no_whitespace_before_comma_in_array' => true,
+    'no_whitespace_in_blank_line' => true,
+    'normalize_index_brace' => true,
+    'not_operator_with_successor_space' => true,
+    'object_operator_without_whitespace' => true,
+    'ordered_imports' => ['sort_algorithm' => 'alpha'],
+    'phpdoc_indent' => true,
+    'general_phpdoc_tag_rename' => true,
+    'phpdoc_no_access' => true,
+    'phpdoc_no_package' => true,
+    'phpdoc_no_useless_inheritdoc' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_single_line_var_spacing' => true,
+    'phpdoc_summary' => true,
+    'phpdoc_to_comment' => false,
+    'phpdoc_trim' => true,
+    'phpdoc_types' => true,
+    'phpdoc_var_without_name' => true,
+    'psr_autoloading' => true,
+    'self_accessor' => true,
+    'short_scalar_cast' => true,
+    'simplified_null_return' => false, // disabled by Shift
+    'single_blank_line_at_eof' => true,
+    'single_blank_line_before_namespace' => true,
+    'single_class_element_per_statement' => true,
+    'single_import_per_statement' => false,
+    'single_line_after_imports' => true,
+    'no_unused_imports' => true,
+    'single_line_comment_style' => [
+        'comment_types' => ['hash'],
+    ],
+    'single_quote' => true,
+    'space_after_semicolon' => true,
+    'standardize_not_equals' => true,
+    'switch_case_semicolon_to_colon' => true,
+    'switch_case_space' => true,
+    'ternary_operator_spaces' => true,
+    'trailing_comma_in_multiline' => true,
+    'trim_array_spaces' => true,
+    'unary_operator_spaces' => true,
+    'whitespace_after_comma_in_array' => true,
+];
+
+$project_path = getcwd();
+$finder = Finder::create()
+    ->in([
+        $project_path . '/src',
+    ])
+    ->name('*.php')
+    ->notName('*.blade.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return (new Config())
+    ->setFinder($finder)
+    ->setRules($rules)
+    ->setRiskyAllowed(true)
+    ->setUsingCache(true);

--- a/check
+++ b/check
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+offer_run() {
+    read -p "For more output, run $1. Run it now (Y/n)? " run
+
+    case ${run:0:1} in
+        n|N )
+            exit 1
+        ;;
+        * )
+            $1
+        ;;
+    esac
+
+    exit 1
+}
+
+if (php-cs-fixer fix --dry-run --config=.php-cs-fixer.php > /dev/null 2>/dev/null); then
+    echo '✅ php-cs-fixer OK'
+else
+    read -p "⚠️ php-cs-fixer found issues. Fix (Y/n)? " fix
+    case ${fix:0:1} in
+        n|N )
+            echo '❌ php-cs-fixer FAIL'
+            offer_run 'php-cs-fixer fix --config=.php-cs-fixer.php'
+        ;;
+        * )
+            if (php-cs-fixer fix --config=.php-cs-fixer.php > /dev/null 2>/dev/null); then
+                echo '✅ php-cs-fixer OK'
+            else
+                echo '❌ php-cs-fixer FAIL'
+                offer_run 'php-cs-fixer fix --config=.php-cs-fixer.php'
+            fi
+        ;;
+    esac
+fi
+
+if (./vendor/bin/phpunit > /dev/null 2>/dev/null); then
+    echo '✅ PHPUnit OK'
+else
+    echo '❌ PHPUnit FAIL'
+    offer_run './vendor/bin/phpunit'
+fi
+
+echo '=================='
+echo '✅ Everything OK'

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         }
     ],
     "require": {
-        "illuminate/database": "^6.0|^8.0|^9.0"
+        "illuminate/database": "^8.0|^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.0",
-        "orchestra/testbench": "^4.0|^6.0|^7.0"
+        "orchestra/testbench": "^6.0|^7.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,12 @@
         }
     ],
     "require": {
-        "php": "^7.2|^7.3|^8.0",
-        "illuminate/database": "^6.0|^7.0|^8.0"
+        "illuminate/database": "^6.0|^8.0|^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4|^9.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0"
-    }
+        "orchestra/testbench": "^4.0|^6.0|^7.0"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/HasManyWithInverse.php
+++ b/src/HasManyWithInverse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Stancl\HasManyWithInverse;
 
 use Illuminate\Database\Eloquent\Model;
@@ -9,11 +11,10 @@ trait HasManyWithInverse
     public function hasManyWithInverse($related, $inverse, $foreignKey = null, $localKey = null, $config = [])
     {
         /** @var Model $this */
-
         $instance = $this->newRelatedInstance($related);
         $foreignKey = $foreignKey ?: $this->getForeignKey();
         $localKey = $localKey ?: $this->getKeyName();
 
-        return new HasManyWithInverseRelationship($instance->newQuery(), $this, $instance->getTable().'.'.$foreignKey, $localKey, $inverse, $config);
+        return new HasManyWithInverseRelationship($instance->newQuery(), $this, $instance->getTable() . '.' . $foreignKey, $localKey, $inverse, $config);
     }
 }

--- a/src/HasManyWithInverseRelationship.php
+++ b/src/HasManyWithInverseRelationship.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Stancl\HasManyWithInverse;
 
 use Illuminate\Database\Eloquent\Builder;


### PR DESCRIPTION
This PR adds support for Laravel 9, check script, and phpcsfixer. 

As I added the CI now and checks are not running. But tests are passing. 
![image](https://user-images.githubusercontent.com/54532330/152186071-a2377f26-6f18-4b19-930b-4afa87578d46.png)
